### PR TITLE
Actualización del glosario de términos

### DIFF
--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -7,8 +7,12 @@
 
 === Glosario de términos técnicos que no serán traducidos
 Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían ser traducidas.  Esta lista no es definitiva y está abierta a discusión.  Si crees que hay una buena traducción para alguna(s) de estas palabras, por favor no dudes en hacer tu sugerencia. 
- commit
- kernel
+
+     caching
+     commit (inconsistente, en algunos capítulos lo traducen, en otros no)
+     hash
+     kernel
+     mirror
 
 === Glosario de términos técnicos que serán traducidos
 
@@ -19,59 +23,97 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 
 ==== *B*
 
+[horizontal]
+*binary installer*:: instalador binario
+*branch*:: ramificación
+*branching*:: raminifaciones
+
+
 ==== *C*
 
 [horizontal]
-
+*checksum*:: suma de comprobación
+*command line* :: línea de comandos
+*commit*:: confirmación, confirmar
+*commited*:: confirmado
+*compile*:: compilar
 *computer* :: computadora
 *content-addressable* :: contenido localizable
+*credentials*:: credenciales
+
+
 
 ==== *D*
+*distribution*:: distribución
 
 ==== *E*
 
 [horizontal]
-
 *e-book* :: libro digital
 
 ==== *F*
 
 ==== *G*
+[horizontal]
+*Git directory*:: directorio de Git
+*GUI*:: interfaz gráfica de usuario
+*GUIs*:: interfaces gráficas de usuario
 
 ==== *H*
 
 ==== *I*
 
+*installer*:: archivo instalador
+
 ==== *J*
 
 ==== *K*
+[horizontal]
+*key*:: clave
 
 ==== *L*
 
 ==== *M*
+[horizontal]
+*modified*:: modificado
 
 ==== *N*
 
 ==== *O*
 
 ==== *P*
+[horizontal]
+*package*:: paquete
+*package-management*:: administración de paquetes
 
 ==== *Q*
 
 ==== *R*
+[horizontal]
+*repository*:: repositorio
+
 
 ==== *S*
 [horizontal]
+ *settings*:: configuración, propiedades
  *snapshot* :: copia instantánea
  *source code* :: código fuente
+ *staged*:: preparado
+ *stagin area*:: área de preparación
 
 ==== *T*
 
 ==== *U*
 
 ==== *V*
+[horizontal]
+*version control system*:: sistema de control de versiones
 
 ==== *W*
+[horizontal]
+*workflow*:: flujo de trabajo
+*working directory*:: directorio de trabajo
+*working tree*:: directorio de trabajo
 
 ==== *X*
 

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -9,16 +9,21 @@
 Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían ser traducidas.  Esta lista no es definitiva y está abierta a discusión.  Si crees que hay una buena traducción para alguna(s) de estas palabras, por favor no dudes en hacer tu sugerencia. 
 
      alias
+     blobs
      checksum (inconsistente, Cap2)
      caching
      commit (inconsistente, Cap2)
      glob
-     hash
+     HEAD
+     hash (inconsistente, Cap3)
      hooks
      kernel
      master (inconsistente, Cap2)
      mirror
      origin
+     patch-id
+     stash
+     upstream
 
 === Glosario de términos técnicos que serán traducidos
 
@@ -35,35 +40,41 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 [horizontal]
 *backslash*:: barra invertida
 *binary installer*:: instalador binario
-*branch*::  rama, ramificación
+*branch*::  rama, ramificación, ramificar
 *branches*:: ramas
-*branching*:: ramificaciones
+*branching*:: ramificaciones, ramales
+*branching scheme*:: estilo de ramificación
 
 
 ==== *C*
 
 [horizontal]
 *check out*:: sacar
+*checked out*:: (sobre una rama) activada
 *checkout*:: copia de trabajo
-*checksum*:: suma de comprobación, suma
+*checksum*:: suma de comprobación, suma, suma de control
 *clone*:: clonar
 *collaborator*:: colaborador
 *command*:: comando
 *command line* :: línea de comandos
-*commit*:: confirmación, confirmar
-*commit history*:: historial de confirmaciones
+*commit*:: confirmación, confirmar, confirmación de cambios
+*commit history*:: historial de confirmaciones, línea temporal de confirmaciones de cambio
 *commited*:: confirmado
 *commiter*:: confirmador
 *compile*:: compilar
 *computer* :: computadora
 *content-addressable* :: contenido localizable
 *credentials*:: credenciales
+*credential cache*:: cache de credenciales
 
 
 
 ==== *D*
-*directory*:: directorio
+[horizontal]
+*development cycle*:: ciclo de desarrollo
+*directory*:: directorio, carpeta
 *distribution*:: distribución
+*drawback*:: contrapartida
 
 ==== *E*
 
@@ -73,9 +84,11 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 
 ==== *F*
 [horizontal]
-*fetch*:: traer
+*fast-forward*:: avance rápido
+*fetch*:: traer, recuperar
 *flag*:: opción
 *forward slash*:: barra
+
 
 ==== *G*
 [horizontal]
@@ -87,6 +100,7 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 
 ==== *H*
 [horizontal]
+*hash*:: resumen
 *heading*:: encabezado
 *hosted* hospedado
 
@@ -109,12 +123,16 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 [horizontal]
 *machine parsing*:: analizada por otro programa
 *master*:: maestra
-*merge*:: combinar, unir
+*merge*:: combinar, unir, fusión, integrar
+*merge commit*:: fusión confirmada, confirmar fusión
+*merge conflict*:: conflicto de fusión
+*metadata*:: metadatos
 *modified*:: modificado
 
 ==== *N*
 [horizontal]
 *network*:: red
+*newline*:: retorno de carro
 
 ==== *O*
 [horizontal]
@@ -127,19 +145,25 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 *patch*: parche
 *path*:: ruta
 *patterm*:: patrón
-*pointer*:: puntero
+*pointer*:: puntero, apuntador
+*proposed update*:: propuesta de actualización
 *protocol*:: protocolo
-*pull*:: recibir, traer, combinar
-*push*:: enviar
+*pull*:: recibir, traer, combinar, incorporar, traer y fusionar
+*push*:: enviar, publicar, llevar
 
 ==== *Q*
 
 ==== *R*
 [horizontal]
+*re-merge*:: refusionar
+*rebase*:: reorganizar, reorganización
+*rebasing*:: reorganizando
 *release*:: lanzamiento
+*released*:: liberado
 *regular expression*:: expresión regular
 *remotes* :: remotos
 *repository*:: repositorio
+*root project tree*:: árbol raíz del proyecto
 
 
 
@@ -161,13 +185,18 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 [horizontal]
 *tag*:: etiqueta
 *tagging*:: etiquetado
-*track*:: controlar
+*three-way merge*:: fusión a tres bandas
+*topic branch*:: rama puntual
+*track*:: controlar, rastrear, hacer seguimiento
 *tracked*:: rastreados
+*tracking branch*:: rama de seguimiento
 *tree*: árbol
+*tree object*:: objeto árbol
 
 
 ==== *U*
 [horizontal]
+*unmerged*:: sin fusionar
 *untracked*:: sin rastrear
 *unstaged*:: sin preparar
 

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -104,7 +104,7 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 [horizontal]
 *hash*:: resumen
 *heading*:: encabezado
-*hosted* hospedado
+*hosted*:: hospedado
 
 ==== *I*
 [horizontal]
@@ -114,12 +114,12 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 
 ==== *K*
 [horizontal]
-*key*:: clave
+*key*:: clave, llave
 
 ==== *L*
 [horizontal]
 *lightweight*:: ligera
-*log*:: historial
+*log*:: historial, bitácora
 
 ==== *M*
 [horizontal]
@@ -144,9 +144,9 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 [horizontal]
 *package*:: paquete
 *package-management*:: administración de paquetes
-*patch*: parche
+*patch*:: parche
 *path*:: ruta
-*patterm*:: patrón
+*pattern*:: patrón
 *pointer*:: puntero, apuntador
 *proposed update*:: propuesta de actualización
 *protocol*:: protocolo
@@ -192,7 +192,7 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 *track*:: controlar, rastrear, hacer seguimiento
 *tracked*:: rastreados
 *tracking branch*:: rama de seguimiento
-*tree*: árbol
+*tree*:: árbol
 *tree object*:: objeto árbol
 
 

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -12,12 +12,74 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 
 === Glosario de términos técnicos que serán traducidos
 
- computer : computadora
- e-book : libro digital
- snapshot : copia instantánea
- source code : código fuente
- content-addressable : contenido localizable
 
+==== *#*
+
+==== *A*
+
+==== *B*
+
+==== *C*
+
+[horizontal]
+
+*computer* :: computadora
+*content-addressable* :: contenido localizable
+
+==== *D*
+
+==== *E*
+
+[horizontal]
+
+*e-book* :: libro digital
+
+==== *F*
+
+==== *G*
+
+==== *H*
+
+==== *I*
+
+==== *J*
+
+==== *K*
+
+==== *L*
+
+==== *M*
+
+==== *N*
+
+==== *O*
+
+==== *P*
+
+==== *Q*
+
+==== *R*
+
+==== *S*
+[horizontal]
+ *snapshot* :: copia instantánea
+ *source code* :: código fuente
+
+==== *T*
+
+==== *U*
+
+==== *V*
+
+==== *W*
+
+==== *X*
+
+==== *Y*
+
+==== *Z*
+ 
+ 
 === Estado de la traducción
 
 A medida que traduzca el trabajo, por favor, actualice el archivo `status.json` para indicar el porcentaje completado de cada archivo. Esto se mostrará en varias páginas para dar a conocer la cantidad de trabajo que queda por hacer.

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -105,7 +105,7 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 *hosted* hospedado
 
 ==== *I*
-
+[horizontal]
 *installer*:: archivo instalador
 
 ==== *J*

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -86,8 +86,10 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 [horizontal]
 *fast-forward*:: avance rápido
 *fetch*:: traer, recuperar
+*file*:: archivo
 *flag*:: opción
 *forward slash*:: barra
+*filesystem*:: sistema de archivos
 
 
 ==== *G*

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -8,11 +8,17 @@
 === Glosario de términos técnicos que no serán traducidos
 Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían ser traducidas.  Esta lista no es definitiva y está abierta a discusión.  Si crees que hay una buena traducción para alguna(s) de estas palabras, por favor no dudes en hacer tu sugerencia. 
 
+     alias
+     checksum (inconsistente, Cap2)
      caching
-     commit (inconsistente, en algunos capítulos lo traducen, en otros no)
+     commit (inconsistente, Cap2)
+     glob
      hash
+     hooks
      kernel
+     master (inconsistente, Cap2)
      mirror
+     origin
 
 === Glosario de términos técnicos que serán traducidos
 
@@ -20,22 +26,34 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 ==== *#*
 
 ==== *A*
+[horizontal]
+*author*:: autor
+*annotated*:: anotada
 
 ==== *B*
 
 [horizontal]
+*backslash*:: barra invertida
 *binary installer*:: instalador binario
-*branch*:: ramificación
-*branching*:: raminifaciones
+*branch*::  rama, ramificación
+*branches*:: ramas
+*branching*:: ramificaciones
 
 
 ==== *C*
 
 [horizontal]
-*checksum*:: suma de comprobación
+*check out*:: sacar
+*checkout*:: copia de trabajo
+*checksum*:: suma de comprobación, suma
+*clone*:: clonar
+*collaborator*:: colaborador
+*command*:: comando
 *command line* :: línea de comandos
 *commit*:: confirmación, confirmar
+*commit history*:: historial de confirmaciones
 *commited*:: confirmado
+*commiter*:: confirmador
 *compile*:: compilar
 *computer* :: computadora
 *content-addressable* :: contenido localizable
@@ -44,22 +62,33 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 
 
 ==== *D*
+*directory*:: directorio
 *distribution*:: distribución
 
 ==== *E*
 
 [horizontal]
 *e-book* :: libro digital
+*environment*:: ambiente
 
 ==== *F*
+[horizontal]
+*fetch*:: traer
+*flag*:: opción
+*forward slash*:: barra
 
 ==== *G*
 [horizontal]
 *Git directory*:: directorio de Git
+*graph*:: gráfico
 *GUI*:: interfaz gráfica de usuario
 *GUIs*:: interfaces gráficas de usuario
 
+
 ==== *H*
+[horizontal]
+*heading*:: encabezado
+*hosted* hospedado
 
 ==== *I*
 
@@ -72,38 +101,75 @@ Las palabras que aparecen abajo son aquellas que, _en mi opinión_, no deberían
 *key*:: clave
 
 ==== *L*
+[horizontal]
+*lightweight*:: ligera
+*log*:: historial
 
 ==== *M*
 [horizontal]
+*machine parsing*:: analizada por otro programa
+*master*:: maestra
+*merge*:: combinar, unir
 *modified*:: modificado
 
 ==== *N*
+[horizontal]
+*network*:: red
 
 ==== *O*
+[horizontal]
+*output*:: salida
 
 ==== *P*
 [horizontal]
 *package*:: paquete
 *package-management*:: administración de paquetes
+*patch*: parche
+*path*:: ruta
+*patterm*:: patrón
+*pointer*:: puntero
+*protocol*:: protocolo
+*pull*:: recibir, traer, combinar
+*push*:: enviar
 
 ==== *Q*
 
 ==== *R*
 [horizontal]
+*release*:: lanzamiento
+*regular expression*:: expresión regular
+*remotes* :: remotos
 *repository*:: repositorio
+
 
 
 ==== *S*
 [horizontal]
+ *server*:: servidor
  *settings*:: configuración, propiedades
- *snapshot* :: copia instantánea
+ *shell*:: terminal
+ *short status*:: estatus abreviado
+ *snapshot* :: copia instantánea, instantánea
  *source code* :: código fuente
+ *stage*:: preparar
  *staged*:: preparado
- *stagin area*:: área de preparación
+ *staging area*:: área de preparación
+ *stashing*:: esconder archivos
+ *string*:: cadena
 
 ==== *T*
+[horizontal]
+*tag*:: etiqueta
+*tagging*:: etiquetado
+*track*:: controlar
+*tracked*:: rastreados
+*tree*: árbol
+
 
 ==== *U*
+[horizontal]
+*untracked*:: sin rastrear
+*unstaged*:: sin preparar
 
 ==== *V*
 [horizontal]


### PR DESCRIPTION
Recopilación de términos técnicos traducidos en los tres primeros capítulos, hay inconsistencias en la traducción, las he añadido por documentarlas hasta que se llegue a un consenso en la traducción de las palabras conflictivas