### PR TITLE
Cambio de palabra ramales.

### DIFF
--- a/book/03-git-branching/1-git-branching.asc
+++ b/book/03-git-branching/1-git-branching.asc
@@ -2,9 +2,9 @@
 == Ramificaciones en Git
 
 (((branches)))
-Cualquier sistema de control de versiones moderno tiene algún mecanismo para soportar distintos ramales.
+Cualquier sistema de control de versiones moderno tiene algún mecanismo para soportar el uso de ramas.
 Cuando hablamos de ramificaciones, significa que tú has tomado la rama principal de desarrollo (master) y a partir de ahí has continuado trabajando sin seguir la rama principal de desarrollo.
-En muchas sistemas de control de versiones este proceso es costoso, pues a menudo requiere crear una nueva copia del código, lo cual puede tomar mucho tiempo cuando se trata de proyectos grandes.
+En muchos sistemas de control de versiones este proceso es costoso, pues a menudo requiere crear una nueva copia del código, lo cual puede tomar mucho tiempo cuando se trata de proyectos grandes.
 
 Algunas personas resaltan que uno de los puntos más fuertes de Git es su sistema de ramificaciones y lo cierto es que esto le hace resaltar sobre los otros sistemas de control de versiones.
 ¿Por qué esto es tan importante?


### PR DESCRIPTION
Cuando se estudia el uso de ramas en git siempre se hace uso de la palabra rama o ramas, no he leído un libro o post donde se refieran a ellas como ramales, aunque bien la palabra es correcta y usada de forma adecuada, el termino no es común.