### PR TITLE
powershell.asc Traducido al Español

### DIFF
--- a/book/A-git-in-other-environments/sections/powershell.asc
+++ b/book/A-git-in-other-environments/sections/powershell.asc
@@ -1,15 +1,13 @@
 [[_git_powershell]]
-=== Git in Powershell
+=== Git en Powershell
 
-(((powershell)))(((tab completion, powershell)))(((shell prompts, powershell)))
-(((posh-git)))
-The standard command-line terminal on Windows (`cmd.exe`) isn't really capable of a customized Git experience, but if you're using Powershell, you're in luck.
-A package called Posh-Git (https://github.com/dahlbyk/posh-git[]) provides powerful tab-completion facilities, as well as an enhanced prompt to help you stay on top of your repository status. It looks like this:
+El terminal de la línea de comandos estándar en Windows (`cmd.exe`) no es realmente capaz de ofrecer una experiencia personalizada en Git, pero si está utilizando Powershell tiene mucha suerte.
+Un paquete llamado Posh-Git(https://github.com/dahlbyk/posh-git[]) proporciona comodidades poderosas para la completación de pestañas, así como un prompt mejorado para ayudarle a mantenerse al tanto sobre el estado de su repositorio. Se ve de esta manera: 
 
-.Powershell with Posh-git.
+.Powershell con Posh-git.
 image::images/posh-git.png[Powershell with Posh-git.]
 
-If you've installed GitHub for Windows, Posh-Git is included by default, and all you have to do is add these lines to your `profile.ps1` (which is usually located in `C:\Users\<username>\Documents\WindowsPowerShell`):
+Si usted ha instalado Github para Windows, Posh-Git se encuentra incluído. Todo lo que tiene que hacer es añadir estas lineas a su `profile.ps1` (El cual se encuentra usualmente en `C:\Users\<username>\Documents\WindowsPowerShell`):
 
 [source,powershell]
 -----
@@ -17,8 +15,8 @@ If you've installed GitHub for Windows, Posh-Git is included by default, and all
 . $env:github_posh_git\profile.example.ps1
 -----
 
-If you're not a GitHub for Windows user, just download a Posh-Git release from (https://github.com/dahlbyk/posh-git[]), and uncompress it to the `WindowsPowershell` directory.
-Then open a Powershell prompt as the administrator, and do this:
+Si no es un usuario de Github para Windows, simplemente descargue una versión de Posh-Git desde (https://github.com/dahlbyk/posh-git[]) y descomprimala en el directorio `WindowsPowershell`.
+Luego abra un prompt de Powershell como administrador y haga lo siguiente:
 
 [source,powershell]
 -----
@@ -27,4 +25,4 @@ Then open a Powershell prompt as the administrator, and do this:
 > .\install.ps1
 -----
 
-This will add the proper line to your `profile.ps1` file, and posh-git will be active the next time you open your prompt.
+Esto añadirá la línea correspondiente a su archivo `profile.ps1` y posh-git estará activo la próxima vez que habra su prompt.


### PR DESCRIPTION
La palabra "prompt" no tiene traducción específica al español en el contexto en el que fue utilizado en este archivo. Se dejó sin traducir.

118 translatable words have been translated to spanish on this file.