### PR TITLE
Regla gramatical "con base en" y no "en base a"

### DIFF
--- a/book/01-introduction/sections/basics.asc
+++ b/book/01-introduction/sections/basics.asc
@@ -28,7 +28,7 @@ Esto también significa que hay muy poco que no puedes hacer si estás desconect
 
 Todo en Git es verificado mediante una suma de comprobación (checksum en inglés) antes de ser almacenado, y es identificado a partir de ese momento mediante dicha suma.  Esto significa que es imposible cambiar los contenidos de cualquier archivo o directorio sin que Git lo sepa.  Esta funcionalidad está integrada en Git al más bajo nivel y es parte integral de su filosofía.  No puedes perder información durante su transmisión o sufrir corrupción de archivos sin que Git sea capaz de detectarlo.
 
-El mecanismo que usa Git para generar esta suma de comprobación se conoce como hash SHA-1.(((SHA-1)))  Se trata de una cadena de 40 caracteres hexadecimales (0-9 y a-f), y se calcula en base a los contenidos del archivo o estructura del directorio en Git.  Un hash SHA-1 se ve de la siguiente forma:
+El mecanismo que usa Git para generar esta suma de comprobación se conoce como hash SHA-1.(((SHA-1)))  Se trata de una cadena de 40 caracteres hexadecimales (0-9 y a-f), y se calcula con base en los contenidos del archivo o estructura del directorio en Git.  Un hash SHA-1 se ve de la siguiente forma:
 
 [source]
 ----


### PR DESCRIPTION
La RAE dice a este respecto que la expresión "en base a" es "censurable" y que "las preposiciones en y a no están justificadas" para el uso de esta expresión.

http://lema.rae.es/dpd/srv/search?key=base