### PR TITLE
Fix meaning of a phrase to match English version

### DIFF
--- a/book/03-git-branching/sections/rebasing.asc
+++ b/book/03-git-branching/sections/rebasing.asc
@@ -52,7 +52,7 @@ Así, la instantánea apuntada por `C4'` es exactamente la misma apuntada por `C
 No hay ninguna diferencia en el resultado final de la integración, pero el haberla hecho reorganizando nos deja un historial más claro.
 Si examinas el historial de una rama reorganizada, este aparece siempre como un historial lineal: como si todo el trabajo se hubiera realizado en series, aunque realmente se haya hecho en paralelo.
 
-Habitualmente, optarás por esta vía cuando quieras estar seguro de que tus confirmaciones de cambio (commits) se pueden aplicar limpiamente sobre una rama remota; posiblemente, en un proyecto donde estés intentando colaborar, pero lleves tú el mantenimiento.
+Habitualmente, optarás por esta vía cuando quieras estar seguro de que tus confirmaciones de cambio (commits) se pueden aplicar limpiamente sobre una rama remota; posiblemente, en un proyecto donde estés intentando colaborar, pero no lleves tú el mantenimiento.
 En casos como esos, puedes trabajar sobre una rama y luego reorganizar lo realizado en la rama `origin/master` cuando lo tengas todo listo para enviarlo al proyecto principal.
 De esta forma, la persona que mantiene el proyecto no necesitará hacer ninguna integración con tu trabajo; le bastará con un avance rápido o una incorporación limpia.
 


### PR DESCRIPTION
In English master version ( https://github.com/progit/progit2/blob/master/book/03-git-branching/sections/rebasing.asc ) says:
"— perhaps in a project to which you’re trying to contribute but that you don’t maintain."
The spanish translation "posiblemente, en un proyecto donde estés intentando colaborar, pero lleves tú el mantenimiento." is wrong because it means the exact opposite og English version.
With my fix (and added "no") it fixes the logic meaning to be the same as in english version.