### PR TITLE
fix: Add sudo keyword to install git on Debian

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -19,7 +19,7 @@ Si estás en Fedora por ejemplo, puedes usar yum:
 Si estás en una distribución basada en Debian como Ubuntu, puedes usar apt-get:
 
 
-  $ apt-get install git
+  $ sudo apt install git
 
 Para opciones adicionales, la página web de Git tiene instrucciones de instalación en diferentes tipos de Unix.  Puedes encontrar esta información en http://git-scm.com/download/linux[].
 


### PR DESCRIPTION
I think that without sudo the command can confuse people that are installing for the first time Git and also in the English version sudo is there.
`sudo apt install git-all`