### PR TITLE
Corrección protocolo

### DIFF
--- a/book/06-github/sections/3-maintaining.asc
+++ b/book/06-github/sections/3-maintaining.asc
@@ -35,17 +35,17 @@ revisa el capítulo <<ch02-git-basics#ch02-git-basics>>.
 
 Ahora que el proyecto está alojado en GitHub, puedes dar la URL a cualquiera
 con quien quieras compartirlo. Cada proyecto en GitHub es accesible mediante
-HTTP como `https://github.com/<usuario>/<proyecto>`, y también con SSH
+HTTPS como `https://github.com/<usuario>/<proyecto>`, y también con SSH
 con la dirección `git@github.com:<usuario>/<proyecto>`.
 Git puede obtener y enviar cambios en ambas URL, ya que tienen control de
 acceso basado en las credenciales del usuario.
 
 [NOTE]
 ====
-Suele ser preferible compartir la URL de tipo HTTP de los proyectos públicos,
+Suele ser preferible compartir la URL de tipo HTTPS de los proyectos públicos,
 puesto que así el usuario no necesitará una cuenta GitHub para clonar el
 proyecto. Si das la dirección SSH, los usuarios necesitarán una cuenta
-GitHub y subir una clave SSH para acceder. Además, la URL HTTP es exactamente
+GitHub y subir una clave SSH para acceder. Además, la URL HTTPS es exactamente
 la misma que usamos para ver la página web del proyecto.
 ====
 
@@ -113,7 +113,7 @@ Técnicamente, podrías fusionar con algo como:
 
 [source,console]
 ----
-$ curl http://github.com/tonychacon/fade/pull/1.patch | git am
+$ curl https://github.com/tonychacon/fade/pull/1.patch | git am
 ----
 
 ===== Colaboración en el Pull Request


### PR DESCRIPTION
Creo que lo correcto sería poner HTTPS y no HTTP, ya que no son lo mismo y podrían llamar a confusión al que no conociese sus diferencias.