### PR TITLE
Corregida redacción en Español del capítulo 5.2 - Contribuyendo a un …

### DIFF
--- a/book/05-distributed-git/sections/contributing.asc
+++ b/book/05-distributed-git/sections/contributing.asc
@@ -101,7 +101,7 @@ Usted y los demás desarrolladores son los únicos que tienen acceso de inserci�
 En este entorno, puede seguir un flujo de trabajo similar a lo que podría hacer al usar Subversion u otro sistema centralizado.
 Aún obtiene las ventajas de cosas como el compromiso fuera de línea y una bifurcación y fusión mucho más simples, pero el flujo de trabajo puede ser muy similar; la principal diferencia es que las fusiones ocurren en el lado del cliente en lugar del servidor en el momento de la confirmación.
 Veamos cómo se vería cuando dos desarrolladores comiencen a trabajar juntos con un repositorio compartido.
-El primer desarrollador, John, clona el repositorio, hace un cambio y se compromete localmente.
+El primer desarrollador, John, clona el repositorio, realiza un commit y se compromete localmente.
 (Los mensajes de protocolo se han reemplazado con `...` en estos ejemplos para acortarlos un poco).
 
 [source,console]
@@ -117,7 +117,7 @@ $ git commit -am 'removed invalid default value'
  1 files changed, 1 insertions(+), 1 deletions(-)
 -----
 
-El segundo desarrollador, Jessica, hace lo mismo: clona el repositorio y comete un cambio:
+La segunda desarrolladora, Jessica, hace lo mismo: clona el repositorio y realiza un commit:
 
 [source,console]
 -----
@@ -132,7 +132,7 @@ $ git commit -am 'add reset task'
  1 files changed, 1 insertions(+), 0 deletions(-)
 -----
 
-Ahora, Jessica lleva su trabajo al servidor:
+Ahora, Jessica lleva su publica su trabajo en el servidor:
 
 [source,console]
 -----
@@ -143,7 +143,7 @@ To jessica@githost:simplegit.git
    1edee6b..fbff5bc  master -> master
 -----
 
-John intenta impulsar su cambio, también:
+John intenta también, publicar su cambio:
 
 [source,console]
 -----
@@ -154,10 +154,10 @@ To john@githost:simplegit.git
 error: failed to push some refs to 'john@githost:simplegit.git'
 -----
 
-John no puede presionar porque Jessica ha presionado mientras tanto.
-Esto es especialmente importante de entender si está acostumbrado a Subversion, porque notará que los dos desarrolladores no editaron el mismo archivo.
-Aunque Subversion realiza automáticamente una fusión de este tipo en el servidor si se editan diferentes archivos, en Git debe fusionar los commit localmente.
-John tiene que buscar los cambios de Jessica y fusionarlos antes de que se le permita presionar:
+John no puede publicar, porque Jessica ha publicado mientras tanto.
+Esto es especialmente importante de entender si está acostumbrado a Subversion, porque notarás que los dos desarrolladores no editaron el mismo archivo.
+Aunque Subversion realiza automáticamente una fusión de este tipo en el servidor si se editan diferentes archivos, en Git se deben fusionar los commits localmente.
+John tiene que recuperar los cambios de Jessica, y fusionarlos antes de que se le permita publcar:
 
 [source,console]
 -----
@@ -172,7 +172,7 @@ En este punto, el repositorio local de John se ve así:
 .John's divergent history.
 image::images/small-team-1.png[John's divergent history.]
 
-John tiene una referencia a los cambios que Jessica elevó, pero tiene que fusionarlos en su propio trabajo antes de que se le permita presionar:
+John tiene una referencia a los cambios que Jessica elevó, pero tiene que fusionarlos en su propio trabajo antes de que se le permita publicar:
 
 [source,console]
 -----
@@ -204,12 +204,12 @@ image::images/small-team-3.png[John's history after pushing to the `origin` serv
 
 Mientras tanto, Jessica ha estado trabajando en una rama temática.
 Ella creó una rama temática llamada `issue54` y realizó tres commits en esa rama.
-Todavía no ha revisado los cambios de John, por lo que su historial de commit se ve así:
+Todavía no ha revisado los cambios de John, por lo que su historial de commits se ve así:
 
 .Jessica's topic branch.
 image::images/small-team-4.png[Jessica's topic branch.]
 
-Jessica quiere sincronizar con John, así que busca:
+Jessica quiere sincronizarse con John, así que recupera su trabajo:
 
 [source,console]
 -----
@@ -220,13 +220,13 @@ From jessica@githost:simplegit
    fbff5bc..72bbc59  master     -> origin/master
 -----
 
-Eso reduce el trabajo que John ha impulsado mientras tanto.
+Eso reduce el trabajo que John ha publicado mientras tanto.
 La historia de Jessica ahora se ve así:
 
 .Jessica's history after fetching John's changes.
 image::images/small-team-5.png[Jessica's history after fetching John's changes.]
 
-Jessica cree que su rama temática está lista, pero quiere saber qué tiene que fusionar en su trabajo para poder impulsarla.
+Jessica cree que su rama temática está lista, pero quiere saber lo que tiene que fusionar en su trabajo para poder publicarla.
 Ella ejecuta `git log` para descubrir:
 
 [source,console]
@@ -239,11 +239,11 @@ Date:   Fri May 29 16:01:27 2009 -0700
    removed invalid default value
 -----
 
-La sintaxis `issue54..origin / master` es un filtro de registro que le pide a Git que sólo muestre la lista de confirmaciones que están en la última rama (en este caso` origen / maestro`) que no están en la primera rama (en este case `issue54`). Repasaremos esta sintaxis en detalle en << _ commit_ranges >>.
+La sintaxis `issue54..origin / master` es un filtro de registro que le pide a Git que sólo muestre la lista de confirmaciones que están en la última rama (en este caso` origin/master`) que no están en la primera rama (en este case `issue54`). Repasaremos esta sintaxis en detalle en << _ commit_ranges >>.
 
-Por ahora, podemos ver en el resultado que hay un compromiso único que John ha realizado en el que Jessica no se ha fusionado. Si fusiona `origen / maestro`, esa es la única confirmación que modificará su trabajo local.
+Por ahora, podemos ver en el resultado que hay un compromiso único que John ha realizado en el que Jessica no se ha fusionado. Si fusiona `origin/master`, esa es la única confirmación que modificará su trabajo local.
 
-Ahora, Jessica puede fusionar su trabajo temático en su rama principal, fusionar el trabajo de John (`origin / master`) en su rama` master`, y luego volver al servidor nuevamente.
+Ahora, Jessica puede fusionar su trabajo temático en su rama principal, fusionar el trabajo de John (`origin/master`) en su rama` master`, y luego volver al servidor nuevamente.
 Primero, vuelve a su rama principal para integrar todo este trabajo:
 
 [source,console]
@@ -253,7 +253,7 @@ Switched to branch 'master'
 Your branch is behind 'origin/master' by 2 commits, and can be fast-forwarded.
 -----
 
-Ella puede fusionar ya sea `origin / master` o` issue54` primero - ambos están en sentido ascendente, por lo que el orden no importa.
+Ella puede fusionar ya sea `origin/master` o` issue54` primero - ambos están en sentido ascendente, por lo que el orden no importa.
 La instantánea final debe ser idéntica sin importar qué orden ella elija; sólo la historia será ligeramente diferente.
 Ella elige fusionarse en `issue54` primero:
 
@@ -267,8 +267,8 @@ Fast forward
  2 files changed, 6 insertions(+), 1 deletions(-)
 -----
 
-No hay problemas como pueden ver, fue un simple avance rápido.
-Ahora Jessica se fusiona en el trabajo de John (`origin / master`):
+No hay problemas. Como pueden ver, fue un simple avance rápido (Fast-foward).
+Ahora Jessica, fusiona en el trabajo de John (`origin/master`):
 
 [source,console]
 -----
@@ -279,12 +279,12 @@ Merge made by recursive.
  1 files changed, 1 insertions(+), 1 deletions(-)
 -----
 
-Todo se funde limpiamente, y la historia de Jessica se ve así:
+Todo se fusiona limpiamente, y la historia de Jessica se ve así:
 
 .Jessica's history after merging John's changes.
 image::images/small-team-6.png[Jessica's history after merging John's changes.]
 
-Ahora `origin / master` es accesible desde la rama` master` de Jessica, por lo que debería poder presionar con éxito (suponiendo que John no haya pulsado nuevamente mientras tanto):
+Ahora `origin/master` es accesible desde la rama` master` de Jessica, por lo que debería poder publicar con éxito (suponiendo que John no haya publicado nuevamente mientras tanto):
 
 [source,console]
 -----
@@ -294,14 +294,14 @@ To jessica@githost:simplegit.git
    72bbc59..8059c15  master -> master
 -----
 
-Cada desarrollador se ha comprometido algunas veces y se ha fusionado el trabajo de cada uno con éxito.
+Cada desarrollador se ha comprometido algunas veces, y se ha fusionado el trabajo de cada uno con éxito.
 
 .Jessica's history after pushing all changes back to the server.
 image::images/small-team-7.png[Jessica's history after pushing all changes back to the server.]
 
 Ese es uno de los flujos de trabajo más simples.
 Trabajas por un tiempo, generalmente en una rama temática, y te unes a tu rama principal cuando está lista para integrarse.
-Cuando desee compartir ese trabajo, hágalo en su propia rama principal, luego busque y combine `origin / master` si ha cambiado, y finalmente presione en la rama` master` del servidor.
+Cuando desee compartir ese trabajo, hágalo en su propia rama principal, luego busque y combine `origin/master` si ha cambiado, y finalmente publique en la rama` master` del servidor.
 La secuencia general es algo como esto:
 
 .General sequence of events for a simple multiple-developer Git workflow.
@@ -314,7 +314,7 @@ En este próximo escenario, observará los roles de los contribuyentes en un gru
 Aprenderá cómo trabajar en un entorno en el que los grupos pequeños colaboran en las funciones y luego esas contribuciones en equipo estarán integradas por otra parte.
 
 Digamos que John y Jessica están trabajando juntos en una característica, mientras que Jessica y Josie están trabajando en una segunda.
-En este caso, la compañía está utilizando un tipo de flujo de trabajo de integración-gerente donde el trabajo de los grupos individuales está integrado sólo por ciertos ingenieros, y la rama `maestra` del repositorio principal sólo puede ser actualizada por esos ingenieros.
+En este caso, la compañía está utilizando un tipo de flujo de trabajo de integración-gerente donde el trabajo de los grupos individuales está integrado sólo por ciertos ingenieros, y la rama `master` del repositorio principal sólo puede ser actualizada por esos ingenieros.
 En este escenario, todo el trabajo se realiza en ramas basadas en equipos y luego los integradores lo agrupan.
 
 Sigamos el flujo de trabajo de Jessica mientras trabaja en sus dos funciones, colaborando en paralelo con dos desarrolladores diferentes en este entorno.
@@ -332,8 +332,8 @@ $ git commit -am 'add limit to log function'
  1 files changed, 1 insertions(+), 1 deletions(-)
 -----
 
-En este punto, ella necesita compartir su trabajo con John, por lo que empuja a su rama `featureA` a comprometerse con el servidor.
-Jessica no tiene acceso de inserción a la rama `maestra`, solo los integradores lo hacen, por lo que debe enviar a otra rama para colaborar con John:
+En este punto, ella necesita compartir su trabajo con John, por lo que publica a su rama `featureA` a comprometerse con el servidor.
+Jessica no tiene acceso de inserción a la rama `master`, solo los integradores lo hacen, por lo que debe enviar a otra rama para colaborar con John:
 
 [source,console]
 -----
@@ -386,7 +386,7 @@ From jessica@githost:simplegit
  * [new branch]      featureBee -> origin/featureBee
 -----
 
-Jessica ahora puede fusionar esto en el trabajo que hizo con `git merge`:
+Jessica ahora puede fusionar esto en el trabajo que hizo, con `git merge`:
 
 [source,console]
 -----
@@ -410,7 +410,7 @@ To jessica@githost:simplegit.git
 
 Esto se llama _refspec_.
 Ver << _ refspec >> para una discusión más detallada de las referencias de Git y diferentes cosas que puedes hacer con ellas.
-También observe la bandera `-u`; esto es la abreviatura de `--set-upstream`, que configura las ramas para empujar y tirar más fácilmente en el futuro.
+También observe la bandera `-u`; esto es la abreviatura de `--set-upstream`, que configura las ramas para publicar y traer, más fácilmente en el futuro.
 
 Luego, John envía un correo electrónico a Jessica para decirle que ha enviado algunos cambios a la rama `featureA` y le pide que los verifique.
 Ella ejecuta un `git fetch` para bajar esos cambios:
@@ -461,13 +461,13 @@ To jessica@githost:simplegit.git
    3300904..774b3ed  featureA -> featureA
 -----
 
-El historial de compromiso de Jessica ahora se ve así:
+El historial de commits de Jessica, ahora se ve así:
 
 .Jessica's history after committing on a feature branch.
 image::images/managed-team-2.png[Jessica's history after committing on a feature branch.]
 
 Jessica, Josie y John informan a los integradores que las ramas `featureA` y` featureBee` en el servidor están listas para su integración en la línea principal.
-Después de que los integradores fusionen estas ramas en la línea principal, una búsqueda reducirá la nueva confirmación de fusión, haciendo que el historial se vea así:
+Después de que los integradores fusionen estas ramas en la línea principal, una búsqueda reducirá el nuevo commit de fusión, haciendo que el historial se vea así:
 
 .Jessica's history after merging both her topic branches.
 image::images/managed-team-3.png[Jessica's history after merging both her topic branches.]
@@ -484,12 +484,12 @@ image::images/managed-team-flow.png[Basic sequence of this managed-team workflow
 
 (((contributing, public small project)))
 Contribuir a proyectos públicos es un poco diferente.
-Como no tiene los permisos para actualizar directamente las ramas en el proyecto, debe obtener el trabajo de otra manera.
-Este primer ejemplo describe la contribución mediante bifurcación en hosts Git que admiten bifurcación fácil.
-Muchos sitios de alojamiento admiten esto (incluidos GitHub, BitBucket, Google Code, repo.or.cz entre otros), y muchos mantenedores de proyectos esperan este estilo de contribución.
+Como no se disponen de los permisos para actualizar directamente las ramas en el proyecto original, se debe obtener el trabajo de otra manera.
+Este primer ejemplo describe la contribución mediante bifurcación (fork), en hosts Git que admiten bifurcación fácil.
+Muchos sitios de alojamiento admiten esto (incluidos GitHub, BitBucket, Google Code, repo.or.cz entre otros), y muchos mantenedores de proyectos, esperan este estilo de contribución.
 La siguiente sección trata de proyectos que prefieren aceptar parches contribuidos por correo electrónico.
 
-En primer lugar, es probable que desee clonar el repositorio principal, crear una rama de tema para el parche o la serie de parches en que planea contribuir y hacer su trabajo allí.
+En primer lugar, es probable que desee clonar el repositorio principal, crear una rama de tema para el parche, o la serie de parches en la que se planea contribuir, y hacer su trabajo allí.
 La secuencia se ve básicamente así:
 
 [source,console]
@@ -505,10 +505,10 @@ $ git commit
 
 [NOTE]
 ====
-Puede usar `rebase -i` para reducir su trabajo a una única confirmación, o reorganizar el trabajo en las confirmaciones para que el desarrollador pueda revisar el parche más fácilmente. Consulte << _ rewriting_history >> para obtener más información sobre el rebase interactivo.
+Puede usar `rebase -i` para reducir su trabajo a un único commit, o reorganizar el trabajo en los commits para que el desarrollador pueda revisar el parche más fácilmente. Consulte << _ rewriting_history >> para obtener más información sobre el rebase interactivo.
 ====
 
-Cuando finalice el trabajo en la rama y esté listo para contribuir con los mantenedores, vaya a la página original del proyecto y haga clic en el botón `` Tenedor '', creando su propio tenedor escribible del proyecto.
+Cuando finalice el trabajo en la rama y esté listo para contribuir con los mantenedores, vaya a la página original del proyecto y haga clic en el botón `` Fork '', creando su propia bifurcación escribible del proyecto.
 Luego debe agregar esta nueva URL de repositorio como segundo control remoto, en este caso llamado `myfork`:
 
 [source,console]
@@ -516,9 +516,9 @@ Luego debe agregar esta nueva URL de repositorio como segundo control remoto, en
 $ git remote add myfork (url)
 -----
 
-Entonces necesitas impulsar tu trabajo hasta esa nua URL.
-Es más fácil impulsar la rama de tema en la que está trabajando hasta su repositorio, en lugar de fusionarse con su rama principal y aumentarla.
-La razón es que si el trabajo no se acepta o se selecciona con una cereza, no es necesario rebobinar la rama maestra.
+Entonces necesitas publicar tu trabajo hasta esa nueva URL.
+Es más fácil publicar la rama de tema en la que está trabajando hasta su repositorio, en lugar de fusionarse con su rama principal y aumentarla.
+La razón es que si el trabajo no se acepta, o se efectua un cherry-pick, no es necesario rebobinar la rama maestra.
 Si los mantenedores se fusionan, redimensionan o seleccionan su trabajo, eventualmente lo recuperará a través de su repositorio de todas maneras:
 
 [source,console]
@@ -554,8 +554,8 @@ Jessica Smith (2):
 
 La salida se puede enviar al mantenedor, le dice de dónde se ramificó el trabajo, resume los compromisos y dice de dónde sacar este trabajo.
 
-En un proyecto para el cual no eres el mantenedor, generalmente es más fácil tener una rama como `master` siempre rastreando` origin / master` y hacer tu trabajo en ramas de tema que puedes descartar fácilmente si son rechazadas.
-Tener temas de trabajo aislados en las ramas temáticas también facilita la tarea de volver a establecer una base de trabajo si la punta del repositorio principal se ha movido mientras tanto y sus confirmaciones ya no se aplican limpiamente.
+En un proyecto para el cual no eres el administrdor, generalmente es más fácil tener una rama como `master` siempre rastreando` origin/master` y hacer tu trabajo en ramas de tema que puedes descartar fácilmente si son rechazadas.
+Tener temas de trabajo aislados en las ramas temáticas también facilita la tarea de volver a establecer una base de trabajo si la punta del repositorio principal se ha movido mientras tanto, y sus commits ya no se aplican limpiamente.
 Por ejemplo, si desea enviar un segundo tema de trabajo al proyecto, no continúe trabajando en la rama de tema que acaba de crear: vuelva a comenzar desde la rama `master` del repositorio principal:
 
 [source,console]
@@ -574,7 +574,7 @@ Ahora, cada uno de sus temas está contenido dentro de un silo, similar a una fi
 image::images/public-small-1.png[Initial commit history with `featureB` work.]
 
 Digamos que el mantenedor del proyecto ha sacado otros parches y ha probado su primera rama, pero ya no se fusiona de manera limpia.
-En este caso, puede tratar de volver a establecer la base de esa rama sobre 'origin / master', resolver los conflictos del mantenedor y luego volver a enviar los cambios:
+En este caso, puede tratar de volver a establecer la base de esa rama sobre 'origin/master', resolver los conflictos del mantenedor y luego volver a enviar los cambios:
 
 [source,console]
 -----
@@ -637,8 +637,8 @@ $ git commit
 
 (((git commands, format-patch)))
 Ahora tiene dos confirmaciones que desea enviar a la lista de correo.
-Utiliza `git format-patch` para generar los archivos con formato mbox que puedes enviar por correo electrónico a la lista: convierte cada confirmación en un mensaje de correo electrónico con la primera línea del mensaje de confirmación como tema y el resto de el mensaje más el parche que introduce el compromiso como el cuerpo.
-Lo bueno de esto es que la aplicación de un parche de un correo electrónico generado con `format-patch` conserva toda la información de compromiso correctamente.
+Utiliza `git format-patch` para generar los archivos con formato mbox que puedes enviar por correo electrónico a la lista: convierte cada commit en un mensaje de correo electrónico, con la primera línea del mensaje del commit como tema y el resto de el mensaje más el parche que introduce el compromiso como el cuerpo.
+Lo bueno de esto es que la aplicación de un parche de un correo electrónico generado con `format-patch` conserva toda la información del commit correctamente.
 
 [source,console]
 -----
@@ -682,7 +682,7 @@ index 76f47bc..f9815f1 100644
 2.1.0
 -----
 
-También puede editar estos archivos de parche para agregar más información para la lista de correo electrónico que no desea mostrar en el mensaje de confirmación.
+También puede editar estos archivos de parche para agregar más información para la lista de correo electrónico que no desea mostrar en el mensaje del commit.
 Si agrega texto entre la línea `---` y el comienzo del parche (la línea `diff - git`), los desarrolladores pueden leerlo; pero aplicar el parche lo excluye.
 
 Para enviarlo por correo electrónico a una lista de correo, puede pegar el archivo en su programa de correo electrónico o enviarlo a través de un programa de línea de comandos.


### PR DESCRIPTION
### English
I have been correcting what I could in the **Spanish** writing of [**chapter 5.2 Git in Distributed Environments - Contributing to a Project**](https://git-scm.com/book/es/v2/Git-en-entornos-distribuidos-Contribuyendo-a-un-Proyecto). So far, it seems to have been translated by an automaton several years ago, without the use of artificial intelligence.
In this way, many key terms, such as 'push,' were translated, for example, as 'press' or 'propel.' The branch name 'origin/master' was translated as 'origen/maestro.'
It is evident, therefore, that the person who made this translation did not even bother to review these kinds of issues before publishing them in this edition of the book in Spanish.
I propose to upload an updated version of the chapter's writing, better reviewed than the previous one.

### Español
Estuve corrigiendo en la medidaque pude, la redacción en **Español** del [**capítulo 5.2 Git en entornos distribuidos - Contribuyendo a un Proyecto**](https://git-scm.com/book/es/v2/Git-en-entornos-distribuidos-Contribuyendo-a-un-Proyecto). Hasta el momento, parece haber sido traducido por un autómata, varios años atrás, sin utilización de inteligencia artificial.
De esta forma, muchas palabras claves como 'push', fueron traducidas por ejemplo, como 'presionar' o 'impulsar'. La denominación de la rama 'origin/master', se encontraba traducida como 'origen/maestro'.
Es evidente así, que la persona que hizo esta traducción, ni siquiera se molestó en revisar este tipo de cuestiones antes de publicarlas en esta edición del libro en Español.
Propongo subir entonces, una actualización de la redacción de este capítulo, mejor revisada que la anterior.